### PR TITLE
Improvements for Cellpose segmentation 

### DIFF
--- a/sopa/cli/segmentation.py
+++ b/sopa/cli/segmentation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+from typing import Iterable, Optional, Union
 
 import typer
 
@@ -25,6 +26,10 @@ def cellpose(
     ),
     clip_limit: float = typer.Option(
         0.2,
+        help="Parameter for skimage.exposure.equalize_adapthist (applied before running cellpose)",
+    ),
+    clahe_kernel_size: Optional[Union[int, Iterable[int]]] = typer.Option(
+        None,
         help="Parameter for skimage.exposure.equalize_adapthist (applied before running cellpose)",
     ),
     gaussian_sigma: float = typer.Option(
@@ -72,6 +77,7 @@ def cellpose(
         channels,
         min_area,
         clip_limit,
+        clahe_kernel_size,
         gaussian_sigma,
         patch_index,
         patch_dir,
@@ -96,6 +102,10 @@ def generic_staining(
     clip_limit: float = typer.Option(
         0.2,
         help="Parameter for skimage.exposure.equalize_adapthist (applied before running the segmentation method)",
+    ),
+    clahe_kernel_size: Optional[Union[int, Iterable[int]]] = typer.Option(
+        None,
+        help="Parameter for skimage.exposure.equalize_adapthist (applied before running cellpose)",
     ),
     gaussian_sigma: float = typer.Option(
         1,
@@ -136,6 +146,7 @@ def generic_staining(
         channels,
         min_area,
         clip_limit,
+        clahe_kernel_size,
         gaussian_sigma,
         patch_index,
         patch_dir,
@@ -149,6 +160,7 @@ def _run_staining_segmentation(
     channels: list[str],
     min_area: float,
     clip_limit: float,
+    clahe_kernel_size: Optional[Union[int, Iterable[int]]],
     gaussian_sigma: float,
     patch_index: int | None,
     patch_dir: str,

--- a/sopa/cli/segmentation.py
+++ b/sopa/cli/segmentation.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import ast
-from typing import Iterable, Optional, Union
+from typing import Iterable
 
 import typer
 
@@ -28,7 +28,7 @@ def cellpose(
         0.2,
         help="Parameter for skimage.exposure.equalize_adapthist (applied before running cellpose)",
     ),
-    clahe_kernel_size: Optional[Union[int, Iterable[int]]] = typer.Option(
+    clahe_kernel_size: int = typer.Option(
         None,
         help="Parameter for skimage.exposure.equalize_adapthist (applied before running cellpose)",
     ),
@@ -103,7 +103,7 @@ def generic_staining(
         0.2,
         help="Parameter for skimage.exposure.equalize_adapthist (applied before running the segmentation method)",
     ),
-    clahe_kernel_size: Optional[Union[int, Iterable[int]]] = typer.Option(
+    clahe_kernel_size: int = typer.Option(
         None,
         help="Parameter for skimage.exposure.equalize_adapthist (applied before running cellpose)",
     ),
@@ -160,7 +160,7 @@ def _run_staining_segmentation(
     channels: list[str],
     min_area: float,
     clip_limit: float,
-    clahe_kernel_size: Optional[Union[int, Iterable[int]]],
+    clahe_kernel_size: int | Iterable[int] | None,
     gaussian_sigma: float,
     patch_index: int | None,
     patch_dir: str,
@@ -178,6 +178,7 @@ def _run_staining_segmentation(
         channels,
         min_area=min_area,
         clip_limit=clip_limit,
+        clahe_kernel_size=clahe_kernel_size,
         gaussian_sigma=gaussian_sigma,
     )
 

--- a/sopa/segmentation/methods.py
+++ b/sopa/segmentation/methods.py
@@ -38,9 +38,10 @@ def cellpose_patch(
 
     cellpose_model_kwargs = cellpose_model_kwargs or {}
 
-    model = models.CellposeModel(
-        model_type=model_type, pretrained_model=pretrained_model, **cellpose_model_kwargs
-    )
+    if pretrained_model:
+        model = models.CellposeModel(pretrained_model=pretrained_model, **cellpose_model_kwargs)
+    else:
+        model = models.Cellpose(model_type=model_type, **cellpose_model_kwargs)
 
     if isinstance(channels, str) or len(channels) == 1:
         channels = [0, 0]  # gray scale

--- a/sopa/segmentation/stainings.py
+++ b/sopa/segmentation/stainings.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Iterable, Optional, Union
 
 import geopandas as gpd
 import numpy as np
@@ -31,6 +31,7 @@ class StainingSegmentation:
         image_key: str | None = None,
         min_area: float = 0,
         clip_limit: float = 0.2,
+        clahe_kernel_size: Optional[Union[int, Iterable[int]]] = None,
         gaussian_sigma: float = 1,
     ):
         """Generalized staining-based segmentation
@@ -79,6 +80,7 @@ class StainingSegmentation:
 
         self.min_area = min_area
         self.clip_limit = clip_limit
+        self.clahe_kernel_size = clahe_kernel_size
         self.gaussian_sigma = gaussian_sigma
 
         self.image_key, self.image = get_spatial_image(sdata, key=image_key, return_key=True)
@@ -105,8 +107,18 @@ class StainingSegmentation:
             y=slice(bounds[1], bounds[3]),
         ).values
 
-        image = gaussian_filter(image, sigma=self.gaussian_sigma)
-        image = exposure.equalize_adapthist(image, clip_limit=self.clip_limit)
+        if len(self.channels) == 1:
+            if self.gaussian_sigma > 0:
+                image = gaussian_filter(image, sigma=self.gaussian_sigma)
+            if self.clip_limit > 0:
+                image = exposure.equalize_adapthist(image, clip_limit=self.clip_limit)
+        else:
+            if self.gaussian_sigma > 0:
+                image = np.stack([gaussian_filter(c, sigma=self.gaussian_sigma) for c in image])
+            if self.clip_limit > 0:
+                image = np.stack(
+                    [exposure.equalize_adapthist(c, clip_limit=self.clip_limit) for c in image]
+                )
 
         if patch.area < box(*bounds).area:
             image = image * shapes.rasterize(patch, image.shape[1:], bounds)

--- a/sopa/segmentation/stainings.py
+++ b/sopa/segmentation/stainings.py
@@ -117,7 +117,14 @@ class StainingSegmentation:
                 image = np.stack([gaussian_filter(c, sigma=self.gaussian_sigma) for c in image])
             if self.clip_limit > 0:
                 image = np.stack(
-                    [exposure.equalize_adapthist(c, clip_limit=self.clip_limit) for c in image]
+                    [
+                        exposure.equalize_adapthist(
+                            c,
+                            clip_limit=self.clip_limit,
+                            kernel_size=self.clahe_kernel_size,
+                        )
+                        for c in image
+                    ]
                 )
 
         if patch.area < box(*bounds).area:

--- a/sopa/segmentation/stainings.py
+++ b/sopa/segmentation/stainings.py
@@ -111,7 +111,11 @@ class StainingSegmentation:
             if self.gaussian_sigma > 0:
                 image = gaussian_filter(image, sigma=self.gaussian_sigma)
             if self.clip_limit > 0:
-                image = exposure.equalize_adapthist(image, clip_limit=self.clip_limit)
+                image = exposure.equalize_adapthist(
+                    image,
+                    clip_limit=self.clip_limit,
+                    kernel_size=self.clahe_kernel_size,
+                )
         else:
             if self.gaussian_sigma > 0:
                 image = np.stack([gaussian_filter(c, sigma=self.gaussian_sigma) for c in image])


### PR DESCRIPTION
Made the following changes:

- Cellpose weights are now correctly used, previously Cyto3 was always applied instead
- Added an optional parameter clahe_kernel_size for skimage.exposure.equalize_adapthist which can be relevant for very big cells or patches. The default still is 1/8 of patch width and height
- Blur and CLAHE can be disabled by setting the parameter to 0
- If segmentation is run on multiple channels (e.g Nucleus marker + cell boundary marker) blur and CLAHE are now run on every channel separately which prevents spillover of intensities