### PR TITLE
Update config.yaml

### DIFF
--- a/workflow/slurm/config.yaml
+++ b/workflow/slurm/config.yaml
@@ -1,19 +1,22 @@
 cluster:
   "sbatch
     --partition={resources.partition}
-    --cpus-per-task={threads}
+    --cpus-per-task={resources.threads}
     --mem={resources.mem_mb}
     --job-name=smk-{rule}
     --gres=gpu:{resources.gpu}
-    --output=logs/%j" # you can update where the logs will be saved (absolute path, or relative to /.../sopa/workflow)
+    --time={resources.time}
+    --output=logs/{rule}_%j.log" # you can update where the logs will be saved (absolute path, or relative to /.../sopa/workflow)
 default-resources:
-  - partition=shortq
-  - mem_mb=32000
+  - partition=shortq # use the partition/queue name on your cluster
+  - mem_mb=15000
   - gpu=0
+  - threads=8
+  - time="30:00:00"
 restart-times: 0
 max-jobs-per-second: 100
 max-status-checks-per-second: 1
-local-cores: 1
+local-cores: 200
 latency-wait: 60
 jobs: 50
 keep-going: True


### PR DESCRIPTION
This is how I would suggest to update the slurm config.yaml

It adds a sensible default number of threads for HPC and fixes the small typo in specifying the `cluster` command.

It also creates logs which are prefixed with rule name (similarly to what snakemake would do if you run it with `--slurm` instead of specifying `--profile slurm` - if you do that, it would natively save to `slurm_logs/rule_{rule}/%j.log` in `.snakemake` directory), which are easier to read in case of errors - it allowed me to work out which rule needed more memory, for example.

