### PR TITLE
xarray bump

### DIFF
--- a/sopa/_sdata.py
+++ b/sopa/_sdata.py
@@ -7,11 +7,10 @@ from typing import Any, Iterator
 import geopandas as gpd
 import pandas as pd
 from anndata import AnnData
-from datatree import DataTree
 from spatialdata import SpatialData
 from spatialdata.models import SpatialElement
 from spatialdata.transformations import Identity, get_transformation, set_transformation
-from xarray import DataArray
+from xarray import DataArray, DataTree
 
 from ._constants import SopaAttrs, SopaFiles, SopaKeys
 

--- a/sopa/io/explorer/images.py
+++ b/sopa/io/explorer/images.py
@@ -6,12 +6,11 @@ from math import ceil
 
 import numpy as np
 import tifffile as tf
-from datatree import DataTree
 from multiscale_spatial_image import to_multiscale
 from spatialdata import SpatialData
 from spatialdata.transformations import Affine, set_transformation
 from tqdm import tqdm
-from xarray import DataArray
+from xarray import DataArray, DataTree
 
 from ..._sdata import get_intrinsic_cs, get_spatial_image
 from ...utils.image import resize_numpy, scale_dtype

--- a/sopa/io/reader/wsi.py
+++ b/sopa/io/reader/wsi.py
@@ -4,11 +4,10 @@ from pathlib import Path
 from typing import Any
 
 import xarray
-from datatree import DataTree
 from spatialdata import SpatialData
 from spatialdata.models import Image2DModel
 from spatialdata.transformations import Identity, Scale
-from xarray import DataArray
+from xarray import DataArray, DataTree
 
 
 def wsi(

--- a/sopa/patches/infer.py
+++ b/sopa/patches/infer.py
@@ -12,11 +12,10 @@ except ImportError:
 
 import numpy as np
 import tqdm
-from datatree import DataTree
 from spatialdata import SpatialData
 from spatialdata.models import Image2DModel
 from spatialdata.transformations import Scale
-from xarray import DataArray
+from xarray import DataArray, DataTree
 
 from .._constants import SopaKeys
 from .._sdata import get_intrinsic_cs, get_spatial_image

--- a/sopa/patches/patches.py
+++ b/sopa/patches/patches.py
@@ -10,12 +10,11 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 from dask.diagnostics import ProgressBar
-from datatree import DataTree
 from shapely.geometry import GeometryCollection, MultiPolygon, Polygon, box
 from spatialdata import SpatialData
 from spatialdata.models import ShapesModel
 from spatialdata.transformations import get_transformation
-from xarray import DataArray
+from xarray import DataArray, DataTree
 
 from .._constants import EPS, ROI, SopaFiles, SopaKeys
 from .._sdata import (

--- a/sopa/segmentation/tissue.py
+++ b/sopa/segmentation/tissue.py
@@ -6,11 +6,10 @@ import warnings
 import geopandas as gpd
 import numpy as np
 import spatialdata
-from datatree import DataTree
 from shapely.geometry import Polygon
 from spatialdata import SpatialData
 from spatialdata.models import ShapesModel
-from xarray import DataArray
+from xarray import DataArray, DataTree
 
 from .._constants import ROI, SopaAttrs
 from .._sdata import get_intrinsic_cs, get_spatial_element

--- a/sopa/utils/image.py
+++ b/sopa/utils/image.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import dask.array as da
 import dask_image.ndinterp
 import numpy as np
-from datatree import DataTree
 from spatialdata import SpatialData
-from xarray import DataArray
+from xarray import DataArray, DataTree
 
 
 def resize(xarr: DataArray, scale_factor: float) -> da.Array:


### PR DESCRIPTION
Sopa can not be installed with new xarray version xarray 2024.11.0 (due to from datatree import DataTree no longer working). Because of this it can also not be installed with new version of spatialdata 0.2.6. This is small PR to fix these issues.