### PR TITLE
Improve Handling of Baysor Subprocess

### DIFF
--- a/sopa/cli/segmentation.py
+++ b/sopa/cli/segmentation.py
@@ -1,7 +1,7 @@
 import ast
 import sys
-from typing import Iterable
 from subprocess import CalledProcessError
+from typing import Iterable
 
 import typer
 

--- a/sopa/cli/segmentation.py
+++ b/sopa/cli/segmentation.py
@@ -1,5 +1,7 @@
 import ast
+import sys
 from typing import Iterable
+from subprocess import CalledProcessError
 
 import typer
 
@@ -245,7 +247,10 @@ def baysor(
 
     sdata = read_zarr_standardized(sdata_path)
 
-    baysor(sdata, config=config, min_area=min_area, patch_index=patch_index, scale=scale)
+    try:
+        baysor(sdata, config=config, min_area=min_area, patch_index=patch_index, scale=scale)
+    except CalledProcessError as e:
+        sys.exit(e.returncode)
 
     _log_whether_to_resolve(patch_index)
 

--- a/sopa/segmentation/methods/_baysor.py
+++ b/sopa/segmentation/methods/_baysor.py
@@ -2,8 +2,6 @@ import logging
 from functools import partial
 from pathlib import Path
 from subprocess import CalledProcessError
-from threading import Thread
-from queue import Queue
 
 from spatialdata import SpatialData
 
@@ -101,10 +99,7 @@ class BaysorPatch:
 
         _copy_segmentation_config(patch_dir / SopaFiles.TOML_CONFIG_FILE, self.config)
 
-        result = run_process_with_streaming_output(
-            self.baysor_command.split(),
-            cwd=patch_dir
-        )
+        result = run_process_with_streaming_output(self.baysor_command.split(), cwd=patch_dir)
 
         if result.returncode != 0:
             message = f"Baysor error on patch {patch_dir.resolve()} with command `{self.baysor_command}`"

--- a/sopa/utils/utils.py
+++ b/sopa/utils/utils.py
@@ -4,7 +4,6 @@ import sys
 import warnings
 from pathlib import Path
 from threading import Thread
-from queue import Queue
 
 import dask.dataframe as dd
 import geopandas as gpd
@@ -378,7 +377,7 @@ def connect_streams(stream, output_stream):
         stream: input stream
         output_stream: output stream
     """
-    for line in iter(stream.readline, b''):
+    for line in iter(stream.readline, b""):
         output_stream.buffer.write(line)
         output_stream.buffer.flush()
     stream.close()
@@ -395,11 +394,7 @@ def run_process_with_streaming_output(command: list[str] | str, **popen_kwargs):
 
     """
     process = subprocess.Popen(
-        command,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        universal_newlines=False,
-        **popen_kwargs
+        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=False, **popen_kwargs
     )
 
     stdout_thread = Thread(target=connect_streams, args=(process.stdout, sys.stdout))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,6 @@
+import io
+from unittest.mock import patch
+
 import pandas as pd
 import pytest
 from spatialdata.models import PointsModel
@@ -164,3 +167,19 @@ def test_add_spatial_element():
     import shutil
 
     shutil.rmtree("_test_add_spatial_element.zarr")
+
+
+def test_run_process_with_streaming_output():
+    class MockStringIO(io.BytesIO):
+        def __init__(self):
+            super().__init__()
+            self.buffer = self
+
+    # Use patch to temporarily replace sys.stdout with our StringIO object
+    with patch("sys.stdout", new_callable=MockStringIO) as fake_stdout:
+        sopa.utils.utils.run_process_with_streaming_output(["python", "-c", "print(1+1)"])
+
+        # Get the output that was "printed"
+        output = fake_stdout.getvalue().decode("utf-8")
+
+    assert output == "2\n"


### PR DESCRIPTION
A few things I noticed with this

1) The way the `baysor` subprocess is being called, the exit code is not being propagated correctly. `sopa` will exit with status code 1 regardless of `baysor` exit code. When using a workflow manager like nextflow, the exit code can determine retry eligibility. Exit code 1 is usually never eligible for a retry because it implies a logic error but exit code 137 (OOM) for example would be eligible for a retry, so this diff will call `sys.exit` with the `baysor` subprocess exit code when we exit the python interpreter.

2) Baysor can run for a long time and I find myself wondering what's going on with it. To that end it would be nice to stream the stdout/stderr to the parent process stdout/stderr as its running. This diff adds a utility method `run_process_with_streaming_output` to do so and replaces subprocess.run with this utility method 