### PR TITLE
Openslide backend sorting scales fix

### DIFF
--- a/sopa/io/reader/wsi.py
+++ b/sopa/io/reader/wsi.py
@@ -30,7 +30,7 @@ def wsi(
     image_name, img, slide, slide_metadata = _open_wsi(path, backend=backend)
 
     images = {}
-    for level, key in enumerate(list(img.keys())):
+    for level, key in enumerate(sorted(list(img.keys()),key=int)):
         suffix = key if key != "0" else ""
 
         scale_image = DataArray(

--- a/sopa/io/reader/wsi.py
+++ b/sopa/io/reader/wsi.py
@@ -30,7 +30,7 @@ def wsi(
     image_name, img, slide, slide_metadata = _open_wsi(path, backend=backend)
 
     images = {}
-    for level, key in enumerate(sorted(list(img.keys()),key=int)):
+    for level, key in enumerate(sorted(list(img.keys()), key=int)):
         suffix = key if key != "0" else ""
 
         scale_image = DataArray(


### PR DESCRIPTION
In case a wsi has more than 10 levels then the image keys are ordered as: `['0', '1', '10', '2', ...]` when using the `.keys()` function. If a DataTree is initialized with this order the the multiscale image initializtion fails. This patch is sorting the scales for the DataTree generation correctly.