### PR TITLE
Corrected channel order for channel name input from TIF metadata in CosMx reader

### DIFF
--- a/sopa/io/reader/cosmx.py
+++ b/sopa/io/reader/cosmx.py
@@ -268,7 +268,10 @@ def _cosmx_morphology_coords(images_dir: Path) -> list[str]:
     with tifffile.TiffFile(images_paths[0]) as tif:
         description = tif.pages[0].description
         substrings = re.findall(r'"BiologicalTarget": "(.*?)",', description)
-        return substrings
+        channels = re.findall(r'"ChannelId": "(.*?)",', description)
+        stdorder = ['B', 'G', 'Y', 'R', 'U']
+        dictionary = [channels.index(x) for x in stdorder if x in channels]
+        return [substrings[i] for i in dictionary]
 
 
 def _get_cosmx_protein_name(image_path: Path) -> str:

--- a/sopa/io/reader/cosmx.py
+++ b/sopa/io/reader/cosmx.py
@@ -261,11 +261,12 @@ def _cosmx_morphology_coords(images_dir: Path) -> list[str]:
 
     with tifffile.TiffFile(images_paths[0]) as tif:
         description = tif.pages[0].description
+
         substrings = re.findall(r'"BiologicalTarget": "(.*?)",', description)
         channels = re.findall(r'"ChannelId": "(.*?)",', description)
         channel_order = list(re.findall(r'"ChannelOrder": "(.*?)",', description)[0])
-        dictionary = [channels.index(x) for x in channel_order if x in channels]
-        return [substrings[i] for i in dictionary]
+
+        return [substrings[channels.index(x)] for x in channel_order if x in channels]
 
 
 def _get_cosmx_protein_name(image_path: Path) -> str:

--- a/sopa/io/reader/cosmx.py
+++ b/sopa/io/reader/cosmx.py
@@ -263,8 +263,8 @@ def _cosmx_morphology_coords(images_dir: Path) -> list[str]:
         description = tif.pages[0].description
         substrings = re.findall(r'"BiologicalTarget": "(.*?)",', description)
         channels = re.findall(r'"ChannelId": "(.*?)",', description)
-        stdorder = ['B', 'G', 'Y', 'R', 'U']
-        dictionary = [channels.index(x) for x in stdorder if x in channels]
+        channel_order = list(re.findall(r'"ChannelOrder": "(.*?)",', description)[0])
+        dictionary = [channels.index(x) for x in channel_order if x in channels]
         return [substrings[i] for i in dictionary]
 
 


### PR DESCRIPTION
Adjusted indexing of the CosMx reader's TIF metadata scraper to ensure channels are output in the same order as they were when `Morphology_ChannelID_Dictionary.txt` was used to get channel names. #180 