### PR TITLE
Debug _cosmx_morphology_coords when one or more morphology channels are unused

### DIFF
--- a/sopa/io/reader/cosmx.py
+++ b/sopa/io/reader/cosmx.py
@@ -290,7 +290,7 @@ def _cosmx_morphology_coords(images_dir: Path) -> list[str]:
         channels = re.findall(r'"ChannelId": "(.*?)",', description)
         channel_order = list(re.findall(r'"ChannelOrder": "(.*?)",', description)[0])
 
-        return [substrings[channels.index(x)] for x in channel_order if x in channels]
+        return [substrings[channels.index(x)] if x in channels else x for x in channel_order]
 
 
 def _get_cosmx_protein_name(image_path: Path) -> str:


### PR DESCRIPTION
When one or more morphology channels has no biological target, returns those channels' single-letter names to the morphology coordinates. This prevents an error caused by mismatching dimensions with the shape of the TIF dask array, which always includes all 5 channels. Fixes #255 