### PR TITLE
Feat/min patch size parameter

### DIFF
--- a/sopa/cli/segmentation.py
+++ b/sopa/cli/segmentation.py
@@ -34,7 +34,7 @@ def cellpose(
         1, help="Parameter for scipy gaussian_filter (applied before running cellpose)"
     ),
     min_patch_size: int = typer.Option(
-        5,
+        10,
         help="Minimum patch size (in pixels) for both width and height. Patches smaller than this will be skipped to avoid segmentation errors.",
     ),
     patch_index: int = typer.Option(
@@ -106,7 +106,7 @@ def stardist(
         help="Parameter for scipy gaussian_filter (applied before running the segmentation method)",
     ),
     min_patch_size: int = typer.Option(
-        5,
+        10,
         help="Minimum patch size (in pixels) for both width and height. Patches smaller than this will be skipped to avoid segmentation errors.",
     ),
     patch_index: int = typer.Option(
@@ -171,7 +171,7 @@ def generic_staining(
         help="Parameter for scipy gaussian_filter (applied before running the segmentation method)",
     ),
     min_patch_size: int = typer.Option(
-        5,
+        10,
         help="Minimum patch size (in pixels) for both width and height. Patches smaller than this will be skipped to avoid segmentation errors.",
     ),
     patch_index: int = typer.Option(
@@ -227,7 +227,7 @@ def _run_staining_segmentation(
     gaussian_sigma: float,
     patch_index: int | None,
     cache_dir_name: str | None,
-    min_patch_size: int = 5,
+    min_patch_size: int = 10,
     **method_kwargs: Any,
 ):
     from sopa.io.standardize import read_zarr_standardized

--- a/sopa/segmentation/_stainings.py
+++ b/sopa/segmentation/_stainings.py
@@ -33,7 +33,7 @@ class StainingSegmentation:
         clip_limit: float = 0.2,
         clahe_kernel_size: int | Iterable[int] | None = None,
         gaussian_sigma: float = 1,
-        min_patch_size: int = 5,
+        min_patch_size: int = 10,
     ):
         """Generalized staining-based segmentation class
 

--- a/sopa/segmentation/methods/_custom.py
+++ b/sopa/segmentation/methods/_custom.py
@@ -21,7 +21,7 @@ def custom_staining_based(
     gaussian_sigma: float = 1,
     cache_dir_name: str = SopaKeys.CUSTOM_BOUNDARIES,
     key_added: str = SopaKeys.CUSTOM_BOUNDARIES,
-    min_patch_size: int = 5,
+    min_patch_size: int = 10,
 ):
     """Run a generic staining-based segmentation model, and add a GeoDataFrame containing the cell boundaries.
 


### PR DESCRIPTION
Add a min patch size parameter (defaults to 10 pixels) to discard very small patches that could potentially break the pipeline. 

closes #280 