### PR TITLE
Fix CosMx morphology marker names that have forward slashes in them

### DIFF
--- a/sopa/io/reader/cosmx.py
+++ b/sopa/io/reader/cosmx.py
@@ -510,7 +510,7 @@ def _get_morphology_coords(images_dir: Path) -> list[str]:
         channels = re.findall(r'"ChannelId": "(.*?)",', description)
         channel_order = list(re.findall(r'"ChannelOrder": "(.*?)",', description)[0])
 
-        return [substrings[channels.index(x)] if x in channels else x for x in channel_order]
+        return [substrings[channels.index(x)].replace("/", ".") if x in channels else x for x in channel_order]
 
 
 def _get_protein_name(image_path: Path) -> str:


### PR DESCRIPTION
Fixes #311. Forward slash is the only potentially invalid character in CosMx morphology marker names. This fix changes the key from the Morphology2D TIFFs to be identical to the format used in the flatfiles (i.e. a period instead of a forward slash).