### PR TITLE
Do not save the cache column in the transcript patches to allow moving the `.zarr` directory before segmentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Ensure that cell expansion with no overlap preserves a polygon output (#318)
 - Fixed `proseg` usage on CosMx data (#323)
 - Don't perform segmentation on extremely small patches @Marius1311 (#282)
+- Do not save the cache column in the transcript patches to allow moving the `.zarr` directory before segmentation
 
 ### Broken changes
 - The CosMX reader now stores the transcript coordinates in microns instead of pixels, so Baysor/Comseg config need to be adjusted (#323)

--- a/sopa/_constants.py
+++ b/sopa/_constants.py
@@ -11,7 +11,6 @@ class SopaKeys:
     PATCHES = "image_patches"
     TRANSCRIPTS_PATCHES = "transcripts_patches"
     EMBEDDINGS_PATCHES = "embeddings_patches"
-    CACHE_PATH_KEY = "cache_path"
     BOUNDS = "bboxes"
     PATCHES_ILOCS = "ilocs"
     ROI = "region_of_interest"

--- a/sopa/patches/_transcripts.py
+++ b/sopa/patches/_transcripts.py
@@ -120,7 +120,6 @@ class OnDiskTranscriptPatches(Patches2D):
         assert len(valid_indices), "No valid patches found. Check the minimum number of points or cells per patch."
 
         geo_df = self.geo_df.iloc[valid_indices].copy()
-        geo_df[SopaKeys.CACHE_PATH_KEY] = geo_df.index.map(lambda index: str(self.cache_dir / str(index)))
         geo_df[SopaKeys.POINTS_KEY] = self.points_key
 
         if self.prior_shapes_key:

--- a/sopa/segmentation/_transcripts.py
+++ b/sopa/segmentation/_transcripts.py
@@ -16,7 +16,7 @@ from tqdm import tqdm
 from .. import shapes
 from .._constants import SopaKeys
 from ..aggregation import count_transcripts
-from ..utils import add_spatial_element
+from ..utils import add_spatial_element, get_transcripts_patches_dirs
 from . import solve_conflicts
 
 log = logging.getLogger(__name__)
@@ -185,7 +185,7 @@ def _check_transcript_patches(sdata: SpatialData, with_prior: bool = False):
         "Transcript patches not found in the SpatialData object. Run `sopa.make_transcript_patches(...)` first."
     )
 
-    directories = [Path(path) for path in sdata[SopaKeys.TRANSCRIPTS_PATCHES][SopaKeys.CACHE_PATH_KEY]]
+    directories: list[Path] = get_transcripts_patches_dirs(sdata)
 
     assert all(directory.exists() for directory in directories), (
         "Some patch directories are missing. "

--- a/sopa/segmentation/methods/_baysor.py
+++ b/sopa/segmentation/methods/_baysor.py
@@ -69,7 +69,7 @@ def baysor(
     baysor_patch = BaysorPatch(baysor_command, config, force=force, capture_output=patch_index is None)
 
     if patch_index is not None:
-        patch_dir = Path(sdata.shapes[SopaKeys.TRANSCRIPTS_PATCHES].loc[patch_index, SopaKeys.CACHE_PATH_KEY])
+        patch_dir = get_transcripts_patches_dirs(sdata, patch_index)
         baysor_patch(patch_dir)
         return
 

--- a/sopa/segmentation/methods/_comseg.py
+++ b/sopa/segmentation/methods/_comseg.py
@@ -61,7 +61,7 @@ def comseg(
     config["prior_name"] = sdata[SopaKeys.TRANSCRIPTS_PATCHES][SopaKeys.PRIOR_SHAPES_KEY].iloc[0]
 
     if patch_index is not None:
-        patch_dir = Path(sdata.shapes[SopaKeys.TRANSCRIPTS_PATCHES].loc[patch_index, SopaKeys.CACHE_PATH_KEY])
+        patch_dir = get_transcripts_patches_dirs(sdata, patch_index)
         comseg_patch(patch_dir, config, recover)
         return
 

--- a/sopa/utils/utils.py
+++ b/sopa/utils/utils.py
@@ -345,14 +345,24 @@ def delete_cache(sdata: SpatialData | None = None) -> None:
             shutil.rmtree(sub_dir)
 
 
-def get_transcripts_patches_dirs(sdata: SpatialData) -> list[Path]:
+def get_transcripts_patches_dirs(sdata: SpatialData, index: int | None = None) -> list[Path] | Path:
     """Get the list of directories containing the transcript patches
 
     Args:
         sdata: A `SpatialData` object containing the transcript patches.
+
+    Returns:
+        If `index` is None, a list of `Path` to the directories containing the transcript patches. Else, the `Path` to the directory of the patch with the given index.
     """
     assert SopaKeys.TRANSCRIPTS_PATCHES in sdata.shapes, "Transcript patches not found in the SpatialData object"
-    return [Path(p) for p in sdata.shapes[SopaKeys.TRANSCRIPTS_PATCHES][SopaKeys.CACHE_PATH_KEY]]
+
+    cache_dir = get_cache_dir(sdata) / SopaFiles.TRANSCRIPT_CACHE_DIR
+
+    if index is not None:
+        assert index in sdata.shapes[SopaKeys.TRANSCRIPTS_PATCHES].index, f"Patch index {index} not found"
+        return cache_dir / str(index)
+
+    return [cache_dir / str(index) for index in sdata.shapes[SopaKeys.TRANSCRIPTS_PATCHES].index]
 
 
 def delete_transcripts_patches_dirs(sdata: SpatialData):


### PR DESCRIPTION
Until now, we have saved the transcript patches location (absolute path) as a column in the corresponding GeoDataFrame.

The idea behind this is to be able to retrieve the cache even if a user does the following: running sopa in-memory until making the transcript patches, then saving the data on disk, and then running segmentation. **[Use case 1]**

But it was failing if the user did the following: saving the SpatialData object on disk, making the transcript patches, moving the SpatialData .zarr to another location, and then running segmentation. **[Use case 2]**

Both cases should be extremely rare, but case 2 is happening when running `nf-core/sopa` on AWS Batch, because the working directory changes.

This PR fixes **[Use case 2]** while breaking **[Use case 1]**. The rationale is that, if **[Use case 1]** happens (which is supposed to happen very rarely), then we have a meaningful error message explaining to just re-run the transcript patches. I think this is acceptable.

What do you think @kweisscure51?