### PR TITLE
Support visium-hd for snakemake

### DIFF
--- a/docs/tutorials/snakemake.md
+++ b/docs/tutorials/snakemake.md
@@ -3,7 +3,7 @@
 Sopa comes with an existing [Snakemake](https://snakemake.readthedocs.io/en/stable/) workflow to get started quickly. This will not involve any coding but requires some setup specific to `snakemake`.
 
 !!! info
-    If you're more familiar with Nextflow, you can try [nf-core/sopa](https://nf-co.re/sopa/dev/) instead.
+    If you're more familiar with Nextflow, you can try [nf-core/sopa](https://nf-co.re/sopa/) instead.
 
 ## Setup
 
@@ -119,6 +119,19 @@ You can either execute the pipeline locally or on a high-performance-cluster (ch
 
 
 For more customization, see the [snakemake CLI documentation](https://snakemake.readthedocs.io/en/stable/executing/cli.html).
+
+### Visium HD usage
+
+For Visium HD, the full-resolution microscopy image (not the cytassist image) is required by Sopa as we’ll run cell segmentation on the H&E full-resolution slide. Therefore, you'll need to also pass `fullres_image_file=/path/to_fullres_image` to the config in the command line:
+
+```sh
+snakemake \
+    --config data_path=/path/to/directory fullres_image_file=/path/to_fullres_image \
+    --configfile=config/visium_hd/stardist.yaml \
+    --workflow-profile profile/slurm  # or any profile you want
+```
+
+Note that, here, `data_path` should be the output directory of Space Ranger. If you want to run Space Ranger within the pipeline (and not separately), refer to the [`nf-core` version of Sopa](https://nf-co.re/sopa).
 
 ## Toy example
 

--- a/docs/tutorials/visium_hd.ipynb
+++ b/docs/tutorials/visium_hd.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "**Important notes**:\n",
     "\n",
-    "- This API tutorial assumes you already ran Space Ranger. If you didn't, you can consider running the full sopa pipeline for Visium HD via Nextflow (see [`nf-core/sopa`](https://nf-co.re/sopa/dev/))\n",
+    "- This API tutorial assumes you already ran Space Ranger. If you didn't, you can consider running the full sopa pipeline for Visium HD via Nextflow (see [`nf-core/sopa`](https://nf-co.re/sopa/))\n",
     "- If Space Ranger produced files with no prefix (for instance, `feature_slice.h5`), then pass `dataset_id=\"\"` to the reader below.\n",
     "- If your full resolution microscopy image is not stored in the `microscope_image`, you need to provide `fullres_image_file` as below. Else, it will be found automatically. This is not necessary if you have prior 10X Genomics segmentation (in which case you can diectly use proseg).\n"
    ]

--- a/uv.lock
+++ b/uv.lock
@@ -4781,7 +4781,7 @@ wheels = [
 
 [[package]]
 name = "sopa"
-version = "2.2.2"
+version = "2.2.6"
 source = { editable = "." }
 dependencies = [
     { name = "anndata" },
@@ -4836,7 +4836,7 @@ requires-dist = [
     { name = "dask", extras = ["distributed"], specifier = ">=2024.4.1" },
     { name = "igraph", specifier = ">=0.11.0" },
     { name = "loompy", marker = "extra == 'baysor'", specifier = ">=3.0.7" },
-    { name = "ome-zarr", specifier = "!=0.14.0" },
+    { name = "ome-zarr", specifier = "<0.14.0" },
     { name = "scanpy", specifier = ">=1.10.4" },
     { name = "spatialdata", specifier = ">=0.7.2" },
     { name = "spatialdata-io", specifier = ">=0.3.0" },

--- a/workflow/config/README.md
+++ b/workflow/config/README.md
@@ -1,21 +1,7 @@
 # Pipeline config files
 
-Sopa's config are `.yaml` files, they work for both `snakemake` and `nextflow`. We provide many examples of such a config in this directory.
+Sopa's config are `.yaml` files. We provide many examples of such a config in this directory.
+
 You can choose an existing one (inside the directory corresponding to your technology of interest) or make your own config.
 
 All arguments are detailed in the [`example_commented.yaml`](https://github.com/prism-oncology/sopa/blob/main/workflow/config/example_commented.yaml) file.
-
-### Usage as a Nextflow `-params-file`
-
-If running Sopa with `nextflow`, you can directly use these files from GitHub without downloading them.
-
-For instance, if you want to use the Xenium proseg config at `https://github.com/prism-oncology/sopa/blob/main/workflow/config/xenium/proseg.yaml`, just click on the "Raw" button from the GitHub interface (top right) to access its raw content.
-
-Then, pass this "raw-content" URL to the `-params-file` option when running `nextflow`, for instance:
-
-```sh
--params-file https://raw.githubusercontent.com/prism-oncology/sopa/refs/heads/main/workflow/config/xenium/proseg.yaml
-```
-
-> [!NOTE]
-> This `-params-file` option is **not** specific to Sopa - you can list other Nextflow params inside it. In that case, make your own local params-file.

--- a/workflow/config/visium_hd/README.md
+++ b/workflow/config/visium_hd/README.md
@@ -1,0 +1,12 @@
+# Visium HD usage
+
+For Visium HD, the full-resolution microscopy image (not the cytassist image) is required by Sopa as we’ll run cell segmentation on the H&E full-resolution slide. Therefore, you'll need to also pass `fullres_image_file=/path/to_fullres_image` to the config in the command line:
+
+```sh
+snakemake \
+    --config data_path=/path/to/directory fullres_image_file=/path/to_fullres_image \
+    --configfile=config/visium_hd/stardist.yaml \
+    --workflow-profile profile/slurm  # or any profile you want
+```
+
+More details about the rest of the command [in the docs](https://prism-oncology.github.io/sopa/tutorials/snakemake/#run-snakemake).

--- a/workflow/config/visium_hd/stardist_proseg.yaml
+++ b/workflow/config/visium_hd/stardist_proseg.yaml
@@ -1,14 +1,18 @@
-# Run proseg segmentation on Visium HD data using the 10X Genomics as prior segmentation
-# WARNING: this prior segmentation only exists in recent Visium HD versions.
+# Run proseg segmentation on Visium HD data using Stardist as prior segmentation.
 
 # For parameters details, see this commented example: https://github.com/prism-oncology/sopa/blob/main/workflow/config/example_commented.yaml
 read:
   technology: visium_hd
 
 patchify:
+  patch_width_pixel: 2000
+  patch_overlap_pixel: 50
   patch_width_microns: -1
 
 segmentation:
+  stardist:
+    min_area: 30
+
   proseg:
     prior_shapes_key: auto
 

--- a/workflow/src/validation.py
+++ b/workflow/src/validation.py
@@ -38,6 +38,10 @@ def validate_config(config: dict) -> dict:
             )
         config["patchify"]["patch_width_microns"] = -1
 
+    if "fullres_image_file" in config:  # convenient way to pass the fullres image file path to the reader
+        config["read"]["kwargs"] = config["read"].get("kwargs", {})
+        config["read"]["kwargs"]["fullres_image_file"] = config["fullres_image_file"]
+
     return config
 
 

--- a/workflow/src/validation.py
+++ b/workflow/src/validation.py
@@ -59,9 +59,14 @@ def check_segmentation_methods(config: dict):
     )
 
     if "stardist" in config["segmentation"]:
-        assert not any(method in config["segmentation"] for method in TRANSCRIPT_BASED_METHODS), (
-            "Invalid config. 'stardist' cannot be combined with transcript-based methods"
-        )
+        if config["read"]["technology"] == "visium_hd":
+            assert "proseg" in config["segmentation"], (
+                "Invalid config. 'stardist' can only be used with 'proseg' for 'visium_hd' technology"
+            )
+        else:
+            assert not any(method in config["segmentation"] for method in TRANSCRIPT_BASED_METHODS), (
+                "Invalid config. 'stardist' cannot be combined with transcript-based methods"
+            )
 
 
 def check_prior_shapes_key(config: dict):


### PR DESCRIPTION
Fix https://github.com/prism-oncology/sopa/issues/415

We can now pass the fullres_image directly:
```sh
snakemake --config data_path=/space/ranger/out fullres_image_file=fullres_image.btf [...]
```

@reJELIN, could you please try this branch and let me know if it works for you?
I also added a `stardist_proseg.yaml` config to run both stardist + proseg on top.