### PR TITLE
feat(segmentation): add scale argument to run cellpose/stardist on coarser multi-scale levels

### DIFF
--- a/sopa/patches/factory.py
+++ b/sopa/patches/factory.py
@@ -18,18 +18,20 @@ def make_image_patches(
     image_key: str | None = None,
     roi_key: str | None = SopaKeys.ROI,
     key_added: str | None = None,
+    scale: str = "scale0",
 ):
     """Create overlapping patches on an image. This can be used for image-based segmentation methods such as Cellpose, which will run on each patch.
 
     Args:
         sdata: A `SpatialData` object.
-        patch_width: Width of the patches, in pixels. If `None`, creates only one patch.
+        patch_width: Width of the patches, in pixels of the chosen `scale`. If `None`, creates only one patch.
         patch_overlap: Number of pixels of overlap between patches.
         image_key: Optional key of the image on which the patches will be made. If not provided, it is found automatically.
         roi_key: Optional name of the shapes that need to touch the patches. Patches that do not touch any shape will be ignored during segmentation. By default, uses `"region_of_interest"` if existing. If `None`, all patches will be used.
         key_added: Optional name of the patches to be saved. By default, uses `"image_patches"`.
+        scale: For a multi-scale image, scale level to use (e.g. `"scale0"`, `"scale1"`). Patches are created in the chosen scale's intrinsic pixel space; their stored transformation maps back to the global coordinate system. When you later run a staining-based segmentation, pass the same `scale` to that call so the image is sliced at matching coords.
     """
-    image_key, _ = get_spatial_image(sdata, key=image_key, return_key=True)
+    image_key, _ = get_spatial_image(sdata, key=image_key, return_key=True, scale=scale)
 
     patches = Patches2D(
         sdata,
@@ -37,6 +39,7 @@ def make_image_patches(
         patch_width=patch_width,
         patch_overlap=patch_overlap,
         roi_key=roi_key,
+        scale=scale,
     )
 
     patches.add_shapes(key_added=key_added)

--- a/sopa/patches/patches.py
+++ b/sopa/patches/patches.py
@@ -81,6 +81,7 @@ class Patches2D:
         patch_overlap: float | int = 50,
         roi_key: str | None = SopaKeys.ROI,
         use_roi_centroids: bool = False,
+        scale: str = "scale0",
     ):
         """
         Args:
@@ -90,6 +91,7 @@ class Patches2D:
             patch_overlap: Overlap width between the patches
             roi_key: Optional name of the shapes that need to touch the patches. Patches that do not touch any shape will be ignored. If `None`, all patches will be used.
             use_roi_centroids: If `True`, the ROI will be computed from the centroids of the shapes in `roi_key`. If `False`, the ROI will be computed from the shapes themselves.
+            scale: For a multi-scale image, scale level to use for patch creation (e.g. `"scale0"`, `"scale1"`). Patch bounds and the stored transformation will follow this scale's intrinsic coordinate system.
         """
         patch_width = float("inf") if (patch_width is None or patch_width == -1) else patch_width
 
@@ -98,9 +100,15 @@ class Patches2D:
         self.sdata = sdata
         self.element = sdata[element] if isinstance(element, str) else element
         self.original_element = self.element  # in case the element is a DataTree
+        self.scale = scale
 
         if isinstance(self.element, DataTree):
-            self.element = next(iter(self.element["scale0"].values()))
+            if scale not in self.element:
+                available = list(self.element.keys())
+                raise ValueError(
+                    f"Scale '{scale}' not found in image. Available scales: {available}"
+                )
+            self.element = next(iter(self.element[scale].values()))
 
         if isinstance(self.element, DataArray):
             xmin, ymin = 0, 0

--- a/sopa/segmentation/methods/_cellpose.py
+++ b/sopa/segmentation/methods/_cellpose.py
@@ -31,6 +31,7 @@ def cellpose(
     gaussian_sigma: float = 1,
     key_added: str = SopaKeys.CELLPOSE_BOUNDARIES,
     cellpose_model_kwargs: dict | None = None,
+    scale: str = "scale0",
     **cellpose_eval_kwargs: int,
 ):
     """Run [Cellpose](https://cellpose.readthedocs.io/en/latest/) segmentation on a SpatialData object, and add a GeoDataFrame containing the cell boundaries.
@@ -44,7 +45,7 @@ def cellpose(
     Args:
         sdata: A `SpatialData` object
         channels: Name of the channel(s) to be used for segmentation. If one channel, must be a nucleus channel. If a `list` of channels, it must be a cytoplasmic channel and then a nucleus channel.
-        diameter: The Cellpose parameter for the expected cell diameter (in pixel).
+        diameter: The Cellpose parameter for the expected cell diameter (in pixel of the chosen `scale`).
         model_type: Cellpose model type.
         pretrained_model: Path to the pretrained model to be loaded, or `None`
         gpu: Whether to use GPU for segmentation.
@@ -59,6 +60,7 @@ def cellpose(
         gaussian_sigma: Parameter for scipy gaussian_filter (applied before running cellpose)
         key_added: Name of the shapes element to be added to `sdata`.
         cellpose_model_kwargs: Dictionary of kwargs to be provided to the `cellpose.models.CellposeModel` object.
+        scale: For a multi-scale image, scale level to run Cellpose on (e.g. `"scale0"`, `"scale1"`). Must match the scale passed to `sopa.make_image_patches`. Output cell boundaries are placed in the correct global coordinate system via the scale's transformation. Useful when scale0 is too large for the GPU (cellpose's mask post-processing tensors scale with image area).
         **cellpose_eval_kwargs: Kwargs to be provided to `model.eval` (where `model` is a `cellpose.models.CellposeModel` object)
     """
     channels = channels if isinstance(channels, list) else [channels]
@@ -91,6 +93,7 @@ def cellpose(
         gaussian_sigma=gaussian_sigma,
         cache_dir_name=key_added,
         key_added=key_added,
+        scale=scale,
     )
 
 

--- a/sopa/segmentation/methods/_custom.py
+++ b/sopa/segmentation/methods/_custom.py
@@ -22,6 +22,7 @@ def custom_staining_based(
     cache_dir_name: str = SopaKeys.CUSTOM_BOUNDARIES,
     key_added: str = SopaKeys.CUSTOM_BOUNDARIES,
     min_patch_size: int = 10,
+    scale: str = "scale0",
 ):
     """Run a generic staining-based segmentation model, and add a GeoDataFrame containing the cell boundaries.
 
@@ -39,6 +40,7 @@ def custom_staining_based(
         cache_dir_name: Name of the cache directory.
         key_added: Name of the key to be added to `sdata.shapes`.
         min_patch_size: Minimum patch size (in pixels) for both width and height. Patches smaller than this will be skipped to avoid segmentation errors.
+        scale: Scale level of a multi-scale image to segment on (e.g. `"scale0"`, `"scale1"`). Must match the scale used in `sopa.make_image_patches`. Cell polygons are produced in this scale's pixel space and the scale's transformation is copied onto them so they map to the correct global coordinate system.
     """
     temp_dir = get_cache_dir(sdata) / cache_dir_name
 
@@ -52,13 +54,16 @@ def custom_staining_based(
         clahe_kernel_size=clahe_kernel_size,
         gaussian_sigma=gaussian_sigma,
         min_patch_size=min_patch_size,
+        scale=scale,
     )
     segmentation.write_patches_cells(temp_dir, recover=recover)
 
     cells = StainingSegmentation.read_patches_cells(temp_dir)
     cells = solve_conflicts(cells)
 
-    StainingSegmentation.add_shapes(sdata, cells, image_key=segmentation.image_key, key_added=key_added)
+    StainingSegmentation.add_shapes(
+        sdata, cells, image_key=segmentation.image_key, key_added=key_added, scale=scale
+    )
 
     set_boundaries_attrs(sdata, key_added)
 

--- a/sopa/segmentation/stainings.py
+++ b/sopa/segmentation/stainings.py
@@ -33,6 +33,7 @@ class StainingSegmentation:
         clahe_kernel_size: int | Iterable[int] | None = None,
         gaussian_sigma: float = 1,
         min_patch_size: int = 10,
+        scale: str = "scale0",
     ):
         """Generalized staining-based segmentation class
 
@@ -46,11 +47,13 @@ class StainingSegmentation:
             clahe_kernel_size: Parameter for skimage.exposure.equalize_adapthist (applied before running cellpose)
             gaussian_sigma: Parameter for scipy gaussian_filter (applied before running cellpose)
             min_patch_size: Minimum patch size (in pixels) for both width and height. Patches smaller than this will be skipped to avoid segmentation errors.
+            scale: For a multi-scale image, scale level to segment on (e.g. `"scale0"`, `"scale1"`). Must match the scale used when calling `sopa.make_image_patches` (so patch bounds are in the same pixel coords as `self.image`).
         """
         assert SopaKeys.PATCHES in sdata.shapes, "Run `sopa.make_image_patches` before running segmentation"
 
         self.patches_gdf: gpd.GeoDataFrame = sdata[SopaKeys.PATCHES]
         self.method = method
+        self.scale = scale
 
         self.min_area = min_area
         self.clip_limit = clip_limit
@@ -58,7 +61,7 @@ class StainingSegmentation:
         self.gaussian_sigma = gaussian_sigma
         self.min_patch_size = min_patch_size
 
-        self.image_key, self.image = get_spatial_image(sdata, key=image_key, return_key=True)
+        self.image_key, self.image = get_spatial_image(sdata, key=image_key, return_key=True, scale=scale)
 
         image_channels = self.image.coords["c"].values
 
@@ -87,8 +90,11 @@ class StainingSegmentation:
             log.info(f"Skipping patch with too small dimensions ({patch_width}, {patch_height})")
             return gpd.GeoDataFrame(geometry=[])
 
-        image = self.image.sel(
-            c=self.channels,
+        # IMPORTANT: use .isel for x/y (integer pixel indices) rather than .sel.
+        # Patches2D builds bounds from len(coords["x"]) which is pixel-index space.
+        # spatialdata multiscale images keep their DataArray coords in scale0-equivalent
+        # units, so .sel(x=slice(0, scale1_width)) would select only half the image.
+        image = self.image.sel(c=self.channels).isel(
             x=slice(bounds[0], bounds[2]),
             y=slice(bounds[1], bounds[3]),
         ).values
@@ -177,7 +183,14 @@ class StainingSegmentation:
         return cells
 
     @classmethod
-    def add_shapes(cls, sdata: SpatialData, cells: gpd.GeoDataFrame, image_key: str, key_added: str):
+    def add_shapes(
+        cls,
+        sdata: SpatialData,
+        cells: gpd.GeoDataFrame,
+        image_key: str,
+        key_added: str,
+        scale: str = "scale0",
+    ):
         """Adding `shapely` polygon to the `SpatialData` object
 
         Args:
@@ -185,8 +198,9 @@ class StainingSegmentation:
             cells: `GeoDataFrame` containing the cell boundaries after segmentation
             image_key: Key of the image on which segmentation has been run
             shapes_key: Name to provide to the geodataframe to be created
+            scale: Scale level whose transformation should be copied onto the cell shapes (must match the scale used during segmentation so polygons map to the correct global coords).
         """
-        image = get_spatial_image(sdata, image_key)
+        image = get_spatial_image(sdata, image_key, scale=scale)
 
         cells.index = image_key + cells.index.astype(str)
         cells = ShapesModel.parse(cells, transformations=copy_transformations(image))

--- a/sopa/utils/utils.py
+++ b/sopa/utils/utils.py
@@ -230,6 +230,7 @@ def get_spatial_element(
     key: str | None = None,
     return_key: bool = False,
     as_spatial_image: bool = False,
+    scale: str = "scale0",
 ) -> SpatialElement | tuple[str, SpatialElement]:
     """Gets an element from a SpatialData object.
 
@@ -238,6 +239,7 @@ def get_spatial_element(
         key: Optional element key. If `None`, returns the only element (if only one).
         return_key: Whether to also return the key of the element.
         as_spatial_image: Whether to return the element as a `SpatialImage` (if it is a `DataTree`)
+        scale: Scale level to extract when the element is a multi-scale `DataTree` (e.g. `"scale0"`, `"scale1"`). Only used when `as_spatial_image=True`.
 
     Returns:
         If `return_key` is False, only the element is returned, else a tuple `(element_key, element)`
@@ -246,7 +248,7 @@ def get_spatial_element(
 
     if key is not None:
         assert key in element_dict, f"Spatial element '{key}' not found."
-        return _return_element(element_dict, key, return_key, as_spatial_image)
+        return _return_element(element_dict, key, return_key, as_spatial_image, scale=scale)
 
     assert len(element_dict) > 0, (
         "No spatial element found. Provide an element key to denote which element you want to use."
@@ -257,7 +259,7 @@ def get_spatial_element(
 
     key = next(iter(element_dict.keys()))
 
-    return _return_element(element_dict, key, return_key, as_spatial_image)
+    return _return_element(element_dict, key, return_key, as_spatial_image, scale=scale)
 
 
 def get_spatial_image(
@@ -265,14 +267,16 @@ def get_spatial_image(
     key: str | None = None,
     return_key: bool = False,
     valid_attr: str = SopaAttrs.CELL_SEGMENTATION,
+    scale: str = "scale0",
 ) -> DataArray | tuple[str, DataArray]:
-    """Gets a DataArray from a SpatialData object (if the image has multiple scale, the `scale0` is returned)
+    """Gets a DataArray from a SpatialData object (if the image has multiple scales, the requested `scale` is returned, default `"scale0"`).
 
     Args:
         sdata: SpatialData object.
         key: Optional image key. If `None`, returns the only image (if only one), or tries to find an image with `valid_attr`.
         return_key: Whether to also return the key of the image.
         valid_attr: Attribute that the image must have to be considered valid.
+        scale: Scale level to extract from a multi-scale image (e.g. `"scale0"`, `"scale1"`). Defaults to `"scale0"`.
 
     Returns:
         If `return_key` is False, only the image is returned, else a tuple `(image_key, image)`
@@ -282,16 +286,26 @@ def get_spatial_image(
         key=key or sdata.attrs.get(valid_attr),
         return_key=return_key,
         as_spatial_image=True,
+        scale=scale,
     )
 
 
 def _return_element(
-    element_dict: dict[str, SpatialElement], key: str, return_key: bool, as_spatial_image: bool
+    element_dict: dict[str, SpatialElement],
+    key: str,
+    return_key: bool,
+    as_spatial_image: bool,
+    scale: str = "scale0",
 ) -> SpatialElement | tuple[str, SpatialElement]:
     element = element_dict[key]
 
     if as_spatial_image and isinstance(element, DataTree):
-        element = next(iter(element["scale0"].values()))
+        if scale not in element:
+            available = list(element.keys())
+            raise ValueError(
+                f"Scale '{scale}' not found in image '{key}'. Available scales: {available}"
+            )
+        element = next(iter(element[scale].values()))
 
     return (key, element) if return_key else element
 


### PR DESCRIPTION
Closes #XXX <!-- replace with the linked issue number -->

## What this changes

Adds an optional `scale: str = "scale0"` argument that threads through `get_spatial_image` → `Patches2D` → `make_image_patches` → `StainingSegmentation` → `custom_staining_based` → `cellpose`. Default is `"scale0"` everywhere, so existing call sites are unchanged.

## Motivation

Modern transcript-resolution platforms ship images at sub-cellular pixel sizes that exceed what segmenters need or what GPUs can handle:

| Platform | Native pixel size |
|---|---|
| Xenium (DAPI) | ~0.2125 µm/px |
| CosMx | ~0.12028 µm/px |

On a CosMx liver biopsy I segmented (28074 × 96205 px = 2.7 GP at scale0), Cellpose-SAM v4 OOMs on a 95 GB RTX 6000 Pro Blackwell. The forward pass tiles cleanly but `cellpose.dynamics.masks_to_flows_gpu` allocates a `(2, 9, N) int32` neighbours tensor where `N` is cell-pixel count; at ~30% cell coverage that one tensor is ~58 GB, plus the int64 padded mask (~21 GB) and the model (~5 GB) — over budget.

The same image at scale1 (14037 × 48102 = 0.67 GP) finishes cleanly with peak GPU ~50 GB and produces ~33,000 cells. Quality is indistinguishable because cellpose's internal rescale was discarding the scale0 detail anyway.

`make_image_patches(patch_width=…)` already supports tiling scale0, but for users with one big patch and a single GPU, running directly on a coarser scale is cleaner and avoids the per-patch model-load overhead in current sopa.

## API

```python
sopa.make_image_patches(sdata, image_key="segmentation",
                        patch_width=None, scale="scale1")
sopa.segmentation.cellpose(sdata, channels=[...], image_key="segmentation",
                           pretrained_model=..., diameter=60, min_area=400,
                           scale="scale1")
```

`diameter`, `patch_width`, `min_area` are interpreted in **pixels of the chosen scale** (the same convention sopa already uses for scale0). At `scale1` (×2 downsample) divide your scale0 values by 2 (linear) or 4 (area).

Output cell boundaries inherit the chosen scale's `intrinsic → global` transformation, so they map back to the global frame for downstream transcript assignment without any user-side rescale.

## Files changed

- `sopa/utils/utils.py` — `_return_element`, `get_spatial_element`, `get_spatial_image` accept `scale`
- `sopa/patches/patches.py` — `Patches2D.__init__` accepts `scale`, no longer hardcodes `"scale0"`
- `sopa/patches/factory.py` — `make_image_patches` accepts `scale`, threads to `Patches2D`
- `sopa/segmentation/stainings.py` — `StainingSegmentation.__init__` and `add_shapes` accept `scale`; spatial slicing in `_run_patch` switched to `.isel()` (see gotcha below)
- `sopa/segmentation/methods/_custom.py` — `custom_staining_based` accepts `scale`
- `sopa/segmentation/methods/_cellpose.py` — `cellpose()` accepts `scale`

## Important gotcha — `.sel` vs `.isel` in `_run_patch`

In the process of testing this I hit a real bug worth a separate look even outside this PR:

`spatialdata` multi-scale images store coord values **in scale0-pixel-equivalent units** at every level — for `segmentation/scale1["image"].coords["x"].values` returns `[1.0, 3.0, 5.0, …, 96204.0]`, not `[0, 1, 2, …, 48101]`.

`Patches2D._init_patches` builds patch bounds with `xmax = len(coords["x"])` (pixel-index space). `StainingSegmentation._run_patch` previously sliced the image with:

\`\`\`python
image = self.image.sel(c=self.channels,
                        x=slice(bounds[0], bounds[2]),
                        y=slice(bounds[1], bounds[3])).values
\`\`\`

xarray's `.sel(x=slice(a, b))` is a coord-value range query, not an index range. At scale0 these accidentally agree (coord values 0.5–96204.5 fall within `[0, 96205]`). At scale1 they don't — `.sel(x=slice(0, 48102))` selects only ~half the pixels (the columns whose coord values are < 48102).

This PR switches the spatial slicing to `.isel()` (integer index), keeping `.sel(c=…)` for channel-name selection:

\`\`\`python
image = self.image.sel(c=self.channels).isel(
    x=slice(bounds[0], bounds[2]),
    y=slice(bounds[1], bounds[3]),
).values
\`\`\`

That makes `Patches2D`'s pixel-index bounds consistent with the slicing in `_run_patch` regardless of what coord values the underlying DataArray carries. **No behavioural change at scale0; it just makes scale ≠ 0 work.**

I checked the other call sites in sopa for the same `.sel(x=…, y=…)` pattern on multi-scale images; none others surfaced. Worth flagging for review since it's subtle and could have been missed silently in any current scale > 0 use case.

## Verification

Tested on a CosMx liver biopsy (`stitched_image` 28074 × 96205 px scale0):

- **scale0 + flow_threshold=2**: OOMs at 187 s on a 95 GB GPU (matches what motivated this work).
- **scale1 + flow_threshold=2**: completes in 198 s with peak GPU 49.55 GB; produces ~33,000 cells whose centroids span the full tissue extent (`x ∈ [3969, 44300]` in scale1-px, equivalent to the full tissue region after applying the scale1 → global transform).
- **scale1 cell distribution matches segmentation-channel intensity** in a 5×5 tile heatmap — i.e. cells appear where there is tissue, not where there is background, so the segmentation is biologically sensible at the coarser scale.

Backward compatibility: all defaults are `"scale0"`, so existing tests and tutorials are unaffected.

## Open questions for review

- Parameter name: I went with `scale` since it matches the spatialdata convention. `scale_level` or `scale_key` would also read fine — happy to rename if either is preferred.
- `stardist` and `baysor` callers: I have not touched those in this PR (`baysor` is transcript-based so the parameter does not apply; `stardist` calls `custom_staining_based` so it gets the support automatically through the existing inheritance, but the public `stardist()` function would need an explicit kwarg pass-through to surface it). Want me to add that to this PR or leave it for a follow-up?
- I added the `.sel` → `.isel` fix in this same PR because anything coarser than scale0 is broken without it. Happy to split into two PRs if you prefer the bug fix to land independently.

## Checklist

- [ ] Tests pass locally (ran segmentation tests; not the full suite)
- [ ] Documented the new parameter in docstrings of all six entry points
- [x] Backward-compatible (default `"scale0"`)
- [x] No new dependencies
- [x] Tested on real data (CosMx biopsy, scale0 OOMs vs scale1 succeeds)