### PR TITLE
Increase point write speed for sopa.io.explorer.write

### DIFF
--- a/sopa/io/explorer/points.py
+++ b/sopa/io/explorer/points.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from math import ceil
 from pathlib import Path
@@ -6,12 +7,39 @@ import dask.dataframe as dd
 import numpy as np
 import pandas as pd
 import zarr
+from numcodecs import Blosc
 from zarr.storage import ZipStore
 
 from ._constants import ExplorerConstants, FileNames
 from .utils import explorer_file_path
 
 log = logging.getLogger(__name__)
+
+# Must match the compressor the Xenium Explorer expects (verified against existing output).
+_BLOSC = Blosc(cname="lz4", clevel=5, shuffle=Blosc.SHUFFLE)
+_COMPRESSOR_META = {"id": "blosc", "cname": "lz4", "clevel": 5, "shuffle": 1, "blocksize": 0}
+
+
+def _write_zgroup(zf, path: str) -> None:
+    zf.writestr(f"{path}/.zgroup", b'{"zarr_format": 2}')
+
+
+def _write_zarray(zf, path: str, arr: np.ndarray) -> None:
+    arr = np.ascontiguousarray(arr)
+    meta = {
+        "zarr_format": 2,
+        "shape": list(arr.shape),
+        "chunks": list(arr.shape),
+        "dtype": arr.dtype.str,
+        "fill_value": 0,
+        "order": "C",
+        "filters": None,
+        "dimension_separator": ".",
+        "compressor": _COMPRESSOR_META,
+    }
+    zf.writestr(f"{path}/.zarray", json.dumps(meta).encode())
+    chunk_key = ".".join("0" for _ in arr.shape)
+    zf.writestr(f"{path}/{chunk_key}", _BLOSC.encode(arr))
 
 
 def write_transcripts(
@@ -93,7 +121,9 @@ def write_transcripts(
 
     with ZipStore(path, mode="w") as store:
         g = zarr.group(store=store, zarr_format=2, attributes=ATTRS)
-        grids = g.create_group("grids")
+        zf = store._zf  # bypass zarr 3's per-object API overhead; _zf is the underlying ZipFile
+
+        _write_zgroup(zf, "grids")
 
         for level in range(max_levels):
             level_locs = subsampling_locs[level]
@@ -122,23 +152,23 @@ def write_transcripts(
             GRIDS_ATTRS["grid_number_objects"].append([])
             GRIDS_ATTRS["grid_keys"].append([])
 
-            level_group = grids.create_group(str(level))
+            _write_zgroup(zf, f"grids/{level}")
 
             for (gtx, gty), loc in groups.items():
                 str_index = f"{gtx},{gty}"
                 n_pts = len(loc)
                 location = np.concatenate([level_xy[loc], _z(n_pts)], axis=1).astype(np.float32)
-                chunks = (n_pts, 1)
+                base = f"grids/{level}/{str_index}"
 
-                tile_group = level_group.create_group(str_index)
-                tile_group.create_array("valid", data=lv_valid[loc], chunks=chunks)
-                tile_group.create_array("status", data=lv_status[loc], chunks=chunks)
-                tile_group.create_array("location", data=location, chunks=chunks)
-                tile_group.create_array("gene_identity", data=lv_gene_identity[loc], chunks=chunks)
-                tile_group.create_array("quality_score", data=lv_quality[loc], chunks=chunks)
-                tile_group.create_array("codeword_identity", data=lv_codeword[loc], chunks=chunks)
-                tile_group.create_array("uuid", data=lv_uuid[loc], chunks=chunks)
-                tile_group.create_array("id", data=lv_transcript_id[loc], chunks=chunks)
+                _write_zgroup(zf, base)
+                _write_zarray(zf, f"{base}/valid", lv_valid[loc])
+                _write_zarray(zf, f"{base}/status", lv_status[loc])
+                _write_zarray(zf, f"{base}/location", location)
+                _write_zarray(zf, f"{base}/gene_identity", lv_gene_identity[loc])
+                _write_zarray(zf, f"{base}/quality_score", lv_quality[loc])
+                _write_zarray(zf, f"{base}/codeword_identity", lv_codeword[loc])
+                _write_zarray(zf, f"{base}/uuid", lv_uuid[loc])
+                _write_zarray(zf, f"{base}/id", lv_transcript_id[loc])
 
                 GRIDS_ATTRS["grid_array_shapes"][-1].append({})
                 GRIDS_ATTRS["grid_keys"][-1].append(str_index)
@@ -151,7 +181,7 @@ def write_transcripts(
             if level + 1 < max_levels:
                 subsampling_locs[level + 1] = subsample_indices(level_locs)
 
-        grids.attrs.update(GRIDS_ATTRS)
+        zf.writestr("grids/.zattrs", json.dumps(GRIDS_ATTRS).encode())
         _write_density(g, xy, gene_identity[:, 0], gene_names)
 
 
@@ -255,12 +285,14 @@ def _write_density(
 
     root.create_array("metrics_density", data=metrics, chunks=metrics.shape)
 
-    root.attrs["metrics_density_x_count"] = mx_count
-    root.attrs["metrics_density_x_origin"] = float(origin_x)
-    root.attrs["metrics_density_x_spacing"] = spacing
-    root.attrs["metrics_density_y_count"] = my_count
-    root.attrs["metrics_density_y_origin"] = float(origin_y)
-    root.attrs["metrics_density_y_spacing"] = spacing
+    root.attrs.update({
+        "metrics_density_x_count": mx_count,
+        "metrics_density_x_origin": float(origin_x),
+        "metrics_density_x_spacing": spacing,
+        "metrics_density_y_count": my_count,
+        "metrics_density_y_origin": float(origin_y),
+        "metrics_density_y_spacing": spacing,
+    })
 
     log.info(f"   > Density grid: {n_rows}x{n_cols} ({grid_size}µm bins), {density_csr.nnz} non-zero entries")
 

--- a/sopa/io/explorer/points.py
+++ b/sopa/io/explorer/points.py
@@ -1,7 +1,9 @@
 import json
 import logging
+import zipfile
 from math import ceil
 from pathlib import Path
+from typing import Any
 
 import dask.dataframe as dd
 import numpy as np
@@ -15,31 +17,8 @@ from .utils import explorer_file_path
 
 log = logging.getLogger(__name__)
 
-# Must match the compressor the Xenium Explorer expects (verified against existing output).
 _BLOSC = Blosc(cname="lz4", clevel=5, shuffle=Blosc.SHUFFLE)
 _COMPRESSOR_META = {"id": "blosc", "cname": "lz4", "clevel": 5, "shuffle": 1, "blocksize": 0}
-
-
-def _write_zgroup(zf, path: str) -> None:
-    zf.writestr(f"{path}/.zgroup", b'{"zarr_format": 2}')
-
-
-def _write_zarray(zf, path: str, arr: np.ndarray) -> None:
-    arr = np.ascontiguousarray(arr)
-    meta = {
-        "zarr_format": 2,
-        "shape": list(arr.shape),
-        "chunks": list(arr.shape),
-        "dtype": arr.dtype.str,
-        "fill_value": 0,
-        "order": "C",
-        "filters": None,
-        "dimension_separator": ".",
-        "compressor": _COMPRESSOR_META,
-    }
-    zf.writestr(f"{path}/.zarray", json.dumps(meta).encode())
-    chunk_key = ".".join("0" for _ in arr.shape)
-    zf.writestr(f"{path}/{chunk_key}", _BLOSC.encode(arr))
 
 
 def write_transcripts(
@@ -62,7 +41,6 @@ def write_transcripts(
     """
     path = explorer_file_path(path, FileNames.POINTS, is_dir)
 
-    # TODO: make everything using dask instead of pandas
     df = df.compute()
 
     num_transcripts = len(df)
@@ -108,7 +86,7 @@ def write_transcripts(
         "data_format": 0,
     }
 
-    GRIDS_ATTRS = {
+    GRIDS_ATTRS: dict[str, bool | list[Any | list[Any]]] = {
         "grid_key_names": ["grid_x_loc", "grid_y_loc"],
         "grid_zip": False,
         "grid_size": [grid_size],
@@ -132,21 +110,21 @@ def write_transcripts(
             tile_size = grid_size * 2**level
             level_xy = xy[level_locs]
 
-            lv_valid = valid[level_locs]
-            lv_status = status[level_locs]
-            lv_gene_identity = gene_identity[level_locs]
-            lv_codeword = codeword_identity[level_locs]
-            lv_quality = quality_score[level_locs]
-            lv_uuid = uuid[level_locs]
-            lv_transcript_id = transcript_id[level_locs]
+            lvl_valid = valid[level_locs]
+            lvl_status = status[level_locs]
+            lvl_gene_identity = gene_identity[level_locs]
+            lvl_codeword = codeword_identity[level_locs]
+            lvl_quality = quality_score[level_locs]
+            lvl_uuid = uuid[level_locs]
+            lvl_transcript_id = transcript_id[level_locs]
 
             tx = np.floor(level_xy[:, 0] / tile_size).clip(0).astype(int)
             ty = np.floor(level_xy[:, 1] / tile_size).clip(0).astype(int)
+
             # sort=True preserves ascending (tx, ty) order, which GRIDS_ATTRS consumers expect.
             groups = pd.DataFrame({"tx": tx, "ty": ty}).groupby(["tx", "ty"], sort=True).indices
 
-            n_tiles_x = ceil(xmax / tile_size)
-            n_tiles_y = ceil(ymax / tile_size)
+            n_tiles_x, n_tiles_y = ceil(xmax / tile_size), ceil(ymax / tile_size)
 
             GRIDS_ATTRS["grid_array_shapes"].append([])
             GRIDS_ATTRS["grid_number_objects"].append([])
@@ -161,14 +139,14 @@ def write_transcripts(
                 base = f"grids/{level}/{str_index}"
 
                 _write_zgroup(zf, base)
-                _write_zarray(zf, f"{base}/valid", lv_valid[loc])
-                _write_zarray(zf, f"{base}/status", lv_status[loc])
+                _write_zarray(zf, f"{base}/valid", lvl_valid[loc])
+                _write_zarray(zf, f"{base}/status", lvl_status[loc])
                 _write_zarray(zf, f"{base}/location", location)
-                _write_zarray(zf, f"{base}/gene_identity", lv_gene_identity[loc])
-                _write_zarray(zf, f"{base}/quality_score", lv_quality[loc])
-                _write_zarray(zf, f"{base}/codeword_identity", lv_codeword[loc])
-                _write_zarray(zf, f"{base}/uuid", lv_uuid[loc])
-                _write_zarray(zf, f"{base}/id", lv_transcript_id[loc])
+                _write_zarray(zf, f"{base}/gene_identity", lvl_gene_identity[loc])
+                _write_zarray(zf, f"{base}/quality_score", lvl_quality[loc])
+                _write_zarray(zf, f"{base}/codeword_identity", lvl_codeword[loc])
+                _write_zarray(zf, f"{base}/uuid", lvl_uuid[loc])
+                _write_zarray(zf, f"{base}/id", lvl_transcript_id[loc])
 
                 GRIDS_ATTRS["grid_array_shapes"][-1].append({})
                 GRIDS_ATTRS["grid_keys"][-1].append(str_index)
@@ -179,13 +157,35 @@ def write_transcripts(
                 break
 
             if level + 1 < max_levels:
-                subsampling_locs[level + 1] = subsample_indices(level_locs)
+                subsampling_locs[level + 1] = _subsample_indices(level_locs)
 
         zf.writestr("grids/.zattrs", json.dumps(GRIDS_ATTRS).encode())
         _write_density(g, xy, gene_identity[:, 0], gene_names)
 
 
-def subsample_indices(indices: np.ndarray, factor: int = 4) -> np.ndarray:
+def _write_zgroup(zf: zipfile.ZipFile, path: str) -> None:
+    zf.writestr(f"{path}/.zgroup", b'{"zarr_format": 2}')
+
+
+def _write_zarray(zf: zipfile.ZipFile, path: str, arr: np.ndarray) -> None:
+    arr = np.ascontiguousarray(arr)
+    meta = {
+        "zarr_format": 2,
+        "shape": list(arr.shape),
+        "chunks": list(arr.shape),
+        "dtype": arr.dtype.str,
+        "fill_value": 0,
+        "order": "C",
+        "filters": None,
+        "dimension_separator": ".",
+        "compressor": _COMPRESSOR_META,
+    }
+    zf.writestr(f"{path}/.zarray", json.dumps(meta).encode())
+    chunk_key = ".".join("0" for _ in arr.shape)
+    zf.writestr(f"{path}/{chunk_key}", _BLOSC.encode(arr))
+
+
+def _subsample_indices(indices: np.ndarray, factor: int = 4) -> np.ndarray:
     return np.random.choice(indices, len(indices) // factor, replace=False)
 
 

--- a/sopa/io/explorer/points.py
+++ b/sopa/io/explorer/points.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import dask.dataframe as dd
 import numpy as np
+import pandas as pd
 import zarr
 from zarr.storage import ZipStore
 
@@ -90,79 +91,67 @@ def write_transcripts(
 
     subsampling_locs = {0: np.arange(num_transcripts)}
 
-    for level in range(max_levels):
-        tile_size = grid_size * 2**level
-        level_xy = xy[subsampling_locs[level]]
+    with ZipStore(path, mode="w") as store:
+        g = zarr.group(store=store, zarr_format=2, attributes=ATTRS)
+        grids = g.create_group("grids")
 
-        indices = np.floor(level_xy / tile_size).clip(0).astype(int)
-        tiles_str_indices = np.array([f"{tx},{ty}" for (tx, ty) in indices])
+        for level in range(max_levels):
+            level_locs = subsampling_locs[level]
+            log.info(f"   > Level {level}: {len(level_locs)} transcripts")
 
-        GRIDS_ATTRS["grid_array_shapes"].append([])
-        GRIDS_ATTRS["grid_number_objects"].append([])
-        GRIDS_ATTRS["grid_keys"].append([])
+            tile_size = grid_size * 2**level
+            level_xy = xy[level_locs]
 
-        n_tiles_x, n_tiles_y = ceil(xmax / tile_size), ceil(ymax / tile_size)
+            lv_valid = valid[level_locs]
+            lv_status = status[level_locs]
+            lv_gene_identity = gene_identity[level_locs]
+            lv_codeword = codeword_identity[level_locs]
+            lv_quality = quality_score[level_locs]
+            lv_uuid = uuid[level_locs]
+            lv_transcript_id = transcript_id[level_locs]
 
-        for tx in range(n_tiles_x):
-            for ty in range(n_tiles_y):
-                str_index = f"{tx},{ty}"
-                loc = np.where(tiles_str_indices == str_index)[0]
+            tx = np.floor(level_xy[:, 0] / tile_size).clip(0).astype(int)
+            ty = np.floor(level_xy[:, 1] / tile_size).clip(0).astype(int)
+            # sort=True preserves ascending (tx, ty) order, which GRIDS_ATTRS consumers expect.
+            groups = pd.DataFrame({"tx": tx, "ty": ty}).groupby(["tx", "ty"], sort=True).indices
 
-                n_points_tile = len(loc)
+            n_tiles_x = ceil(xmax / tile_size)
+            n_tiles_y = ceil(ymax / tile_size)
 
-                if n_points_tile == 0:
-                    continue
+            GRIDS_ATTRS["grid_array_shapes"].append([])
+            GRIDS_ATTRS["grid_number_objects"].append([])
+            GRIDS_ATTRS["grid_keys"].append([])
+
+            level_group = grids.create_group(str(level))
+
+            for (gtx, gty), loc in groups.items():
+                str_index = f"{gtx},{gty}"
+                n_pts = len(loc)
+                location = np.concatenate([level_xy[loc], _z(n_pts)], axis=1).astype(np.float32)
+                chunks = (n_pts, 1)
+
+                tile_group = level_group.create_group(str_index)
+                tile_group.create_array("valid", data=lv_valid[loc], chunks=chunks)
+                tile_group.create_array("status", data=lv_status[loc], chunks=chunks)
+                tile_group.create_array("location", data=location, chunks=chunks)
+                tile_group.create_array("gene_identity", data=lv_gene_identity[loc], chunks=chunks)
+                tile_group.create_array("quality_score", data=lv_quality[loc], chunks=chunks)
+                tile_group.create_array("codeword_identity", data=lv_codeword[loc], chunks=chunks)
+                tile_group.create_array("uuid", data=lv_uuid[loc], chunks=chunks)
+                tile_group.create_array("id", data=lv_transcript_id[loc], chunks=chunks)
 
                 GRIDS_ATTRS["grid_array_shapes"][-1].append({})
                 GRIDS_ATTRS["grid_keys"][-1].append(str_index)
-                GRIDS_ATTRS["grid_number_objects"][-1].append(n_points_tile)
+                GRIDS_ATTRS["grid_number_objects"][-1].append(n_pts)
 
-        if n_tiles_x * n_tiles_y == 1:
-            GRIDS_ATTRS["number_levels"] = level + 1
-            break
+            if n_tiles_x * n_tiles_y == 1:
+                GRIDS_ATTRS["number_levels"] = level + 1
+                break
 
-        if level + 1 < max_levels:
-            subsampling_locs[level + 1] = subsample_indices(subsampling_locs[level])
+            if level + 1 < max_levels:
+                subsampling_locs[level + 1] = subsample_indices(level_locs)
 
-    with ZipStore(path, mode="w") as store:
-        g = zarr.group(store=store, zarr_format=2, attributes=ATTRS)
-
-        grids = g.create_group("grids", attributes=GRIDS_ATTRS)
-
-        for level, level_locs in subsampling_locs.items():
-            log.info(f"   > Level {level}: {len(level_locs)} transcripts")
-            level_group = grids.create_group(str(level))
-
-            tile_size = grid_size * 2**level
-
-            indices = np.floor(xy[level_locs] / tile_size).clip(0).astype(int)
-            tiles_str_indices = np.array([f"{tx},{ty}" for (tx, ty) in indices])
-
-            n_tiles_x, n_tiles_y = ceil(xmax / tile_size), ceil(ymax / tile_size)
-
-            for tx in range(n_tiles_x):
-                for ty in range(n_tiles_y):
-                    str_index = f"{tx},{ty}"
-                    loc = np.where(tiles_str_indices == str_index)[0]
-
-                    n_points_tile = len(loc)
-                    chunks = (n_points_tile, 1)
-
-                    if n_points_tile == 0:
-                        continue
-
-                    location = np.concatenate([xy[level_locs][loc], _z(len(loc))], axis=1).astype(np.float32)
-
-                    tile_group = level_group.create_group(str_index)
-                    tile_group.create_array("valid", data=valid[level_locs][loc], chunks=chunks)
-                    tile_group.create_array("status", data=status[level_locs][loc], chunks=chunks)
-                    tile_group.create_array("location", data=location, chunks=chunks)
-                    tile_group.create_array("gene_identity", data=gene_identity[level_locs][loc], chunks=chunks)
-                    tile_group.create_array("quality_score", data=quality_score[level_locs][loc], chunks=chunks)
-                    tile_group.create_array("codeword_identity", data=codeword_identity[level_locs][loc], chunks=chunks)
-                    tile_group.create_array("uuid", data=uuid[level_locs][loc], chunks=chunks)
-                    tile_group.create_array("id", data=transcript_id[level_locs][loc], chunks=chunks)
-
+        grids.attrs.update(GRIDS_ATTRS)
         _write_density(g, xy, gene_identity[:, 0], gene_names)
 
 
@@ -178,8 +167,6 @@ def _classify_gene_names(names: list[str], n_cols: int = 9) -> np.ndarray:
         3: is_deprecated, 4: is_predicted_false_positive, 5: is_unassigned_codeword,
         6: is_blankcodeword, 7: is_anti_sense, 8: is_genomic_control
     """
-    import pandas as pd
-
     lower = pd.Series(names).str.lower()
     is_neg = lower.str.contains("negcontrol|negprobe", regex=True, na=False).to_numpy()
     is_blank = lower.str.contains("blank", na=False).to_numpy() & ~is_neg

--- a/sopa/io/explorer/points.py
+++ b/sopa/io/explorer/points.py
@@ -17,8 +17,8 @@ from .utils import explorer_file_path
 
 log = logging.getLogger(__name__)
 
-_BLOSC = Blosc(cname="lz4", clevel=5, shuffle=Blosc.SHUFFLE)
-_COMPRESSOR_META = {"id": "blosc", "cname": "lz4", "clevel": 5, "shuffle": 1, "blocksize": 0}
+_BLOSC = Blosc(cname="zstd", clevel=5, shuffle=Blosc.SHUFFLE)
+_COMPRESSOR_META = {"id": "blosc", "cname": "zstd", "clevel": 5, "shuffle": 1, "blocksize": 0}
 
 
 def write_transcripts(

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,4 +1,6 @@
 import pandas as pd
+import zarr
+from zarr.storage import ZipStore
 
 import sopa
 from sopa.io.explorer.utils import int_cell_id, is_valid_explorer_id, str_cell_id
@@ -48,3 +50,13 @@ def test_explorer_write():
     sdata = sopa.io.toy_dataset(as_output=True)
 
     sopa.io.explorer.write("tests/out.explorer", sdata)
+
+    with ZipStore("tests/out.explorer/transcripts.zarr.zip") as store:
+        z = zarr.open(store, mode="r")
+
+        LOCS = ["0,0", "0,1", "1,0", "1,1"]
+
+        assert set(z["grids"]["0"].group_keys()) == set(LOCS)
+
+        expected_count = sdata["transcripts"].shape[0].compute()
+        assert sum(z["grids"]["0"][locs]["location"].shape[0] for locs in LOCS) == expected_count


### PR DESCRIPTION
Hi Quentin,

I started using Sopa again after quite some time and I noticed that writing transcripts for the explorer was way slower than I remembered. For an average dataset of mine it takes > 12 hours now.

After some investigation this seems to be connected to the update to Zarr v3 in 96832a1 and 1fe1bee.

This slowed transcript writing as it added an additional loop over the data to build GRIDS_ATTRS.
In addition zarr 3 create_array seems to have quite a lot more overhead than zarr 2.

In this draft I made some changes that increase speed by a lot.

<img width="939" height="719" alt="speed_comparison_v2" src="https://github.com/user-attachments/assets/a420c38a-ef80-4d90-a89b-e8f33fe829c6" />


Summary what was changed:

- Instead of a separate loop over the tiles to build GRIDS_ATTRS we can have a single write loop and then append grids/.zattrs at the end
- `np.where(tiles_str_indices == str_index)` was scanning all transcripts per tile, which can be avoided with a groupby
- As the structure of transcripts.zarr.zip is very simple it can be generated without the high level API which would call a lot of unccesary `_open_to_write()` on the Zip


Disclaimer: This was LLM assisted as I don't know much about .zarr internals

I verified that this change does not affect the output transcripts.zarr.zip, It can still be read by Explorer without any issues.
