### PR TITLE
Fix pandas / AnnData 0.13.0 compatibility

### DIFF
--- a/sopa/spatial/distance.py
+++ b/sopa/spatial/distance.py
@@ -124,7 +124,9 @@ def mean_distance(
 
         if (not ignore_zeros) and (group_key == target_group_key):
             # distance to cell to same group is 0, we don't correct it
-            df_distances.values[np.diag_indices_from(df_distances)] = 0
+            values = df_distances.to_numpy(copy=True)
+            np.fill_diagonal(values, 0)
+            df_distances.iloc[:, :] = values
 
     return df_distances
 

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -126,7 +126,8 @@ def test_aggregation_more_cells():
 
     x, y = transcript_locs.T
 
-    gene_names = np.concatenate([adata_original.var_names.values[None, :].repeat(counts[i]) for i in range(n_cells)])
+    var_names = np.asarray(adata_original.var_names)
+    gene_names = np.concatenate([var_names[None, :].repeat(counts[i]) for i in range(n_cells)])
 
     df_pandas = pd.DataFrame({
         "x": x,


### PR DESCRIPTION
This PR fixes two failures that occur with newer pandas (copy-on-write) and AnnData 0.13.0.

##### Two changes
- In AnnData 0.13, string indices follow pandas new string dtype, so var_names.values now returns pandas.arrays.ArrowStringArray (1-D, rejects 2-D indexing). Test fixed.

- Read-only array error when zeroing the diagonal → fixed by writing to a writable copy.
